### PR TITLE
autoconf: ensure that the m4 directory is included

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_PREREQ(2.58)
 
 AC_INIT([blogbench],[1.1],[j at pureftpd.org])
 AM_INIT_AUTOMAKE([1.8 dist-bzip2])
+AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_LIBOBJ_DIR(src)
 


### PR DESCRIPTION
This was needed on a Fedora 30 builder to avoid a configure error:

    ./configure: line 5788: ACX_PTHREAD: command not found

Signed-off-by: Jeff Layton <jlayton@kernel.org>